### PR TITLE
Adds NYC Event

### DIFF
--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -53,6 +53,7 @@
           href="https://twitter.com/kylestetz">Kyle&nbsp;Stetz</a>. (Or you can
         <a href="mailto:plotterpeople@nornagon.net">email us</a>.)
         </p>
+        <p>Plotter People NYC is run by <a href="https://twitter.com/paulgb">Paul Butler</a> (<a href="mailto:paulgb@gmail.com">email me</a>).</p>
         <div style="clear:both">&nbsp;</div>
       </footer>
       <div class="hidden">

--- a/_posts/2018-12-19-plotter-people-1.md
+++ b/_posts/2018-12-19-plotter-people-1.md
@@ -4,7 +4,7 @@ date: 2019-01-14 18:30:00 -0800
 date_label: Monday Jan 14, 2019<br/>6:30 - 9:00pm
 venue: GitHub SF<br/>[88 Colin P Kelly Jr St,<br/>San Francisco, CA 94107](https://goo.gl/maps/fY73YaqfztR2)
 eventbrite_id: 53937598810
-categories: event
+categories: event-sf
 ---
 
 {::options parse_block_html="true" /}

--- a/_posts/2019-03-13-plotter-people-2.md
+++ b/_posts/2019-03-13-plotter-people-2.md
@@ -4,7 +4,7 @@ date: 2019-03-13 18:30:00 -0800
 date_label: Wednesday March 13, 2019<br/>6:30 - 9:00pm
 venue: GitHub SF<br/>[88 Colin P Kelly Jr St,<br/>San Francisco, CA 94107](https://goo.gl/maps/fY73YaqfztR2)
 eventbrite_id: 56689095611
-categories: event
+categories: event-sf
 ---
 
 {::options parse_block_html="true" /}

--- a/_posts/2019-04-11-plotter-people-nyc-1.md
+++ b/_posts/2019-04-11-plotter-people-nyc-1.md
@@ -1,0 +1,67 @@
+---
+title: "Plotter People NYC #1"
+date: 2019-04-11 18:30:00 -0400
+date_label: Tursday, April 11<br/>6:30 - 9:00pm
+venue: Teachers Pay Teachers<br>[111 E 18th St., NYC](https://goo.gl/maps/Aehh7cPyigL2)
+categories: event-nyc
+---
+{::options parse_block_html="true" /}
+
+The inaugural Plotter People NYC will take place on April 11, 2019. Join us and meet a community of artists, makers, and creative coders who have embraced pen plotting as a medium. Everyone who has an interest in pen plotting is welcome to attend, regardless of experience level.
+
+<div class="when-and-where">
+<div class="when">
+<h4>When</h4>
+{{ page.date_label }}
+</div>
+<div class="where">
+<h4>Where</h4>
+{{ page.venue }}
+</div>
+</div>
+
+Plotter People is free to attend thanks to Teachers Pay Teachers’ generous donation of event
+space, but please RSVP so we can sign you in to the building! To RSVP email paulgb@gmail.com or use the link below.
+
+<a href="mailto:paulgb@gmail.com?subject=PlotterPeople NYC RSVP&body=I’ll be there!" rel="noopener noreferrer" target="_blank" style="background: none">
+<button class="rsvp" type="button">RSVP</button>
+</a>
+
+{% include subscribe-form.html %}
+
+{::options parse_block_html="false" /}
+
+<div class="squiggly">
+	<h2>{{ page.title }}</h2>
+</div>
+
+{::options parse_block_html="true" /}
+
+{:.section-header}
+### Format
+
+The event is organized as a **show-and-tell**. Attendees are encouraged (but not required!) to give a brief (~5 minutes) introduction of themselves, their work, and their process. Plotters of all levels of experience are welcome to present. Participants may show their work in person or prepare a slideshow to be projected.
+
+If you would like to participate in the show-and-tell, please email [paulgb@gmail.com](mailto:paulgb@gmail.com).
+
+### Gallery
+
+The show-and-tell will be accompanied by a gallery in which attendees can display their work.
+
+### Schedule
+
+| 6:30pm | Arrive at {{ page.venue }}.<br/>Make some new friends! |
+| 7:00pm | **Show-and-tell**<br />See what others in the NYC plotter community are working on, and share your work. Everyone is welcome to show their work, mention in your RSVP if you would like to participate! |
+| 8:00pm | **Gallery + Food**<br/>Grab a bite to eat, check out what folks are working on, and ask them questions! |
+| 9:00pm | Head home with a belly full of food and a head full of ideas! |
+
+<a href="mailto:paulgb@gmail.com?subject=PlotterPeople NYC RSVP&body=I’ll be there!" rel="noopener noreferrer" target="_blank" style="background: none">
+<button class="rsvp" type="button">RSVP</button>
+</a>
+
+### Code of Conduct
+
+All attendees, speakers, sponsors, volunteers and organizers are required to
+abide by the [Plotter People Code of Conduct][coc].
+
+[coc]: /conduct.html

--- a/index.md
+++ b/index.md
@@ -1,6 +1,7 @@
 ---
 layout: event
 ---
-{% for post in site.posts limit:1 %}
+{% assign posts = site.posts | where: "categories","event-sf" %}
+{% for post in posts limit:1 %}
 {{post.content}}
 {% endfor %}

--- a/nyc.md
+++ b/nyc.md
@@ -1,0 +1,7 @@
+---
+layout: event
+---
+{% assign posts = site.posts | where: "categories","event-nyc" %}
+{% for post in posts limit:1 %}
+{{post.content}}
+{% endfor %}


### PR DESCRIPTION
This PR adds the NYC event to the PlotterPeople page.

To accomplish this, I moved the existing pages to the "events-sf" category and created an "events-nyc" category. The index.md page filters to only show the latest sf events, and I created a new nyc.md page that only shows the latest NYC event.

The NYC event page and copy borrows heavily from the SF events for consistency.

So far there is no way to discover the /nyc page from the SF page (I haven’t implemented the drop-down). But I wanted to get something out so that I have an event page to link to.

For future events I will use EventBrite but for this one I have been managing the RSVP list manually.